### PR TITLE
Allow setting `site.thumbnail.url` as fallback

### DIFF
--- a/head.html
+++ b/head.html
@@ -24,6 +24,10 @@
 		<meta itemprop="thumbnailUrl" content="{{ page.image }}" />
 		<meta property="og:image" content="{{ page.image }}" />
 		<meta name="twitter:image" content="{{ page.image }}" />
+	{% elsif site.thumbnail.url %}
+		<meta itemprop="thumbnailUrl" content="{{ site.thumbnail.url }}"` />
+		<meta property="og:image" content="{{ site.thumbnail.url }}" />
+		<meta name="twitter:image" content="{{ site.thumbnail.url }}" />`
 	{% elsif site.data.app.screenshots %}
 		{% for screenshot in site.data.app.screenshots %}
 			<meta itemprop="thumbnailUrl" content="{{ screenshot.src }}" />


### PR DESCRIPTION
Any `page.*` image will superseded this.